### PR TITLE
Do not use tab-width for temporary variable

### DIFF
--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -2,7 +2,7 @@
 
 ;; Author: 10sr <8slashes+el [at] gmail [dot] com>
 ;; URL: https://github.com/10sr/editorconfig-core-emacslisp
-;; Version: 0.1.3
+;; Version: 0.1.4
 ;; Keywords: utility editorconfig
 
 ;; This file is not part of GNU Emacs.

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -2,7 +2,7 @@
 
 ;; Author: 10sr <8slashes+el [at] gmail [dot] com>
 ;; URL: https://github.com/10sr/editorconfig-core-emacslisp
-;; Version: 0.1.3
+;; Version: 0.1.4
 ;; Keywords: utility editorconfig
 ;; Package-Requires: ((editorconfig-fnmatch "20151023.1021") (cl-lib "0.5"))
 
@@ -63,7 +63,7 @@
 
 
 (defconst editorconfig-core-version
-  "0.1.3"
+  "0.1.4"
   "EditorConfig core version.")
 
 (defun editorconfig-core--remove-duplicate (alist)

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -155,9 +155,9 @@ This functions returns alist of properties.  Each element will look like
                   (downcase (cdr pair))))))
 
     ;; Add indent_size property
-    (let ((indent-size (assoc "indent_size" result))
-          (tab-width (assoc "tab_width" result)))
-      (when (and (not indent-size)
+    (let ((p-indent-size (assoc "indent_size" result))
+          (p-tab-width (assoc "tab_width" result)))
+      (when (and (not p-indent-size)
                  (string= (cdr (assoc "indent_style" result)) "tab")
                  ;; If VERSION < 0.9.0, indent_size should have no default value
                  (not (editorconfig-core--version-prior-than confversion
@@ -165,20 +165,20 @@ This functions returns alist of properties.  Each element will look like
         (setq result
               `(,@result ("indent_size" . "tab")))))
     ;; Add tab_width property
-    (let ((indent-size (assoc "indent_size" result))
-          (tab-width (assoc "tab_width" result)))
-      (when (and indent-size
-                 (not tab-width)
-                 (not (string= (cdr indent-size) "tab")))
+    (let ((p-indent-size (assoc "indent_size" result))
+          (p-tab-width (assoc "tab_width" result)))
+      (when (and p-indent-size
+                 (not p-tab-width)
+                 (not (string= (cdr p-indent-size) "tab")))
         (setq result
-              `(,@result ("tab_width" . ,(cdr indent-size))))))
+              `(,@result ("tab_width" . ,(cdr p-indent-size))))))
     ;; Update indent-size property
-    (let ((indent-size (assoc "indent_size" result))
-          (tab-width (assoc "tab_width" result)))
-      (when (and indent-size
-                 tab-width
-                 (string= (cdr indent-size) "tab"))
-        (setcdr indent-size (cdr tab-width))))
+    (let ((p-indent-size (assoc "indent_size" result))
+          (p-tab-width (assoc "tab_width" result)))
+      (when (and p-indent-size
+                 p-tab-width
+                 (string= (cdr p-indent-size) "tab"))
+        (setcdr p-indent-size (cdr p-tab-width))))
 
     result))
 

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -156,9 +156,9 @@ This functions returns alist of properties.  Each element will look like
 
     ;; Add indent_size property
     (let ((p-indent-size (assoc "indent_size" result))
-          (p-tab-width (assoc "tab_width" result)))
+          (p-indent-style (assoc "indent_style" result)))
       (when (and (not p-indent-size)
-                 (string= (cdr (assoc "indent_style" result)) "tab")
+                 (string= (cdr p-indent-style) "tab")
                  ;; If VERSION < 0.9.0, indent_size should have no default value
                  (not (editorconfig-core--version-prior-than confversion
                                                              "0.9.0")))


### PR DESCRIPTION
This is defined as a configuration variable and must be an integer.
